### PR TITLE
client.name || client.class

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -59,11 +59,11 @@ local path = string.sub(source, 1, string.find(source, "/[^/]*$"))
 local noicon = path .. "noicon.png"
 
 local function createPreviewText(client)
-  if client.class then
-    return " - " .. client.class
-  else
-    return " - " .. client.name
-  end
+   if client.class then
+      return " - " .. client.class
+   else
+      return " - " .. client.name
+   end
 end
 
 local function preview()

--- a/init.lua
+++ b/init.lua
@@ -58,6 +58,14 @@ local source = string.sub(debug.getinfo(1,'S').source, 2)
 local path = string.sub(source, 1, string.find(source, "/[^/]*$"))
 local noicon = path .. "noicon.png"
 
+local function createPreviewText(client)
+  if client.class then
+    return " - " .. client.class
+  else
+    return " - " .. client.name
+  end
+end
+
 local function preview()
    if not settings.preview_box then return end
 
@@ -104,7 +112,7 @@ local function preview()
    local bigFont = textboxHeight / 2
    cr:set_font_size(fontSize)
    for i = 1, #leftRightTab do
-      text = " - " .. leftRightTab[i].class
+      text = createPreviewText(leftRightTab[i])
       textWidth = cr:text_extents(text).width
       textHeight = cr:text_extents(text).height
       if textWidth > maxTextWidth or textHeight > maxTextHeight then
@@ -166,8 +174,7 @@ local function preview()
 	    cr:set_font_face(cr:get_font_face())
 	    cr:set_font_size(fontSize)
 
-
-	    text = " - " .. c.class
+	    text = createPreviewText(c)
 	    textWidth = cr:text_extents(text).width
 	    textHeight = cr:text_extents(text).height
 

--- a/init.lua
+++ b/init.lua
@@ -26,7 +26,7 @@ local cr = cairo.Context(surface)
 
 -- settings
 
-local settings = { 
+local settings = {
    preview_box = true,
    preview_box_bg = "#ddddddaa",
    preview_box_border = "#22222200",
@@ -66,7 +66,7 @@ local function preview()
    preview_wbox.border_color = settings.preview_box_border
 
    local preview_widgets = {}
-   
+
    -- Make the wibox the right size, based on the number of clients
    local n = math.max(7, #altTabTable)
    local W = screen[mouse.screen].geometry.width -- + 2 * preview_wbox.border_width
@@ -104,7 +104,7 @@ local function preview()
    local bigFont = textboxHeight / 2
    cr:set_font_size(fontSize)
    for i = 1, #leftRightTab do
-      text = " - " .. leftRightTab[i].class 
+      text = " - " .. leftRightTab[i].class
       textWidth = cr:text_extents(text).width
       textHeight = cr:text_extents(text).height
       if textWidth > maxTextWidth or textHeight > maxTextHeight then
@@ -134,7 +134,7 @@ local function preview()
       preview_widgets[i].fit = function(preview_widget, width, height)
    	 return w, h
       end
-      
+
       preview_widgets[i].draw = function(preview_widget, preview_wbox, cr, width, height)
    	 if width ~= 0 and height ~= 0 then
 
@@ -152,12 +152,12 @@ local function preview()
 
 	    -- Icons
 	    local icon
-	    if c.icon == nil then 
+	    if c.icon == nil then
 	       icon = gears.surface(gears.surface.load(noicon))
 	    else
 	       icon = gears.surface(c.icon)
 	    end
-	       
+
 	    local iconboxWidth = 0.9 * textboxHeight
 	    local iconboxHeight = iconboxWidth
 
@@ -165,18 +165,18 @@ local function preview()
 	    cr:select_font_face(unpack(settings.preview_box_title_font))
 	    cr:set_font_face(cr:get_font_face())
 	    cr:set_font_size(fontSize)
-	    
+
 
 	    text = " - " .. c.class
 	    textWidth = cr:text_extents(text).width
 	    textHeight = cr:text_extents(text).height
 
-	    local titleboxWidth = textWidth + iconboxWidth 
+	    local titleboxWidth = textWidth + iconboxWidth
 	    local titleboxHeight = textboxHeight
 
 	    -- Draw icons
 	    tx = (w - titleboxWidth) / 2
-	    ty = h 
+	    ty = h
 	    sx = iconboxWidth / icon.width
 	    sy = iconboxHeight  / icon.height
 
@@ -187,7 +187,7 @@ local function preview()
 	    cr:paint()
 	    cr:scale(1/sx, 1/sy)
 	    cr:translate(-tx, -ty)
-	    
+
 	    -- Draw titles
 	    tx = tx + iconboxWidth
 	    ty = h + (textboxHeight + textHeight) / 2
@@ -200,10 +200,10 @@ local function preview()
 	    -- Draw previews
    	    local cg = c:geometry()
 	    if cg.width > cg.height then
-	       sx = a * w / cg.width 
+	       sx = a * w / cg.width
 	       sy = math.min(sx, a * h / cg.height)
 	    else
-	       sy = a * h / cg.height	       
+	       sy = a * h / cg.height
 	       sx = math.min(sy, a * h / cg.width)
 	    end
 
@@ -227,8 +227,8 @@ local function preview()
       end
 
       preview_live_timer.timeout = 1 / settings.preview_box_fps
-      preview_live_timer:connect_signal("timeout", function() 
-					   preview_widgets[i]:emit_signal("widget::updated") 
+      preview_live_timer:connect_signal("timeout", function()
+					   preview_widgets[i]:emit_signal("widget::updated")
       end)
 
    end
@@ -242,7 +242,7 @@ local function preview()
 
    --layout
    preview_layout = wibox.layout.fixed.horizontal()
-   
+
    preview_layout:add(spacer)
    for i = 1, #leftRightTab do
       preview_layout:add(preview_widgets[i])
@@ -275,7 +275,7 @@ local function cycle(altTabTable, altTabIndex, dir)
    end
 
    altTabTable[altTabIndex].minimized = false
-   
+
    if not settings.preview_box and not settings.client_opacity then
       client.focus = altTabTable[altTabIndex]
    end
@@ -313,7 +313,7 @@ local function switch(dir, alt, tab, shift_tab)
 
    local t = awful.tag.selected(s)
    local all = client.get(s)
-   
+
 
    for i = 1, #all do
       local c = all[i]
@@ -350,7 +350,7 @@ local function switch(dir, alt, tab, shift_tab)
 
    if #altTabTable == 0 then
       return
-   elseif #altTabTable == 1 then 
+   elseif #altTabTable == 1 then
       altTabTable[1].minimized = false
       altTabTable[1]:raise()
       return
@@ -362,10 +362,10 @@ local function switch(dir, alt, tab, shift_tab)
    -- preview delay timer
    local previewDelay = settings.preview_box_delay / 1000
    local previewDelayTimer = timer({timeout = previewDelay})
-   previewDelayTimer:connect_signal("timeout", function() 
+   previewDelayTimer:connect_signal("timeout", function()
 				       preview_wbox.visible = true
 				       previewDelayTimer:stop()
-				       preview(altTabTable, altTabIndex) 
+				       preview(altTabTable, altTabIndex)
    end)
    previewDelayTimer:start()
    preview_live_timer:start()
@@ -373,7 +373,7 @@ local function switch(dir, alt, tab, shift_tab)
    -- opacity delay timer
    local opacityDelay = settings.client_opacity_delay / 1000
    local opacityDelayTimer = timer({timeout = opacityDelay})
-   opacityDelayTimer:connect_signal("timeout", function() 
+   opacityDelayTimer:connect_signal("timeout", function()
 				       applyOpacity = true
 				       opacityDelayTimer:stop()
 				       clientOpacity(altTabTable, altTabIndex)
@@ -384,7 +384,7 @@ local function switch(dir, alt, tab, shift_tab)
    -- Now that we have collected all windows, we should run a keygrabber
    -- as long as the user is alt-tabbing:
    keygrabber.run(
-      function (mod, key, event)  
+      function (mod, key, event)
 	 -- Stop alt-tabbing when the alt-key is released
 	 if key == alt or key == "Escape" and event == "release" then
 	    preview_wbox.visible = false
@@ -392,8 +392,8 @@ local function switch(dir, alt, tab, shift_tab)
 	    preview_live_timer:stop()
 	    previewDelayTimer:stop()
 	    opacityDelayTimer:stop()
-   
-	    if key == "Escape" then 
+
+	    if key == "Escape" then
 	       for i,c in pairs(altTabTable) do
 		  c.opacity = altTabOpacity[i]
 	       end
@@ -414,11 +414,11 @@ local function switch(dir, alt, tab, shift_tab)
 	    -- raise chosen client on top of all
 	    c = altTabTable[altTabIndex]
 	    c:raise()
-	    client.focus = c                  
+	    client.focus = c
 
 	    -- restore minimized clients
 	    for i = 1, #altTabTable do
-	       if i ~= altTabIndex and altTabMinimized[i] then 
+	       if i ~= altTabIndex and altTabMinimized[i] then
 		  altTabTable[i].minimized = true
 	       end
 	       altTabTable[i].opacity = altTabOpacity[i]
@@ -429,7 +429,7 @@ local function switch(dir, alt, tab, shift_tab)
       	    -- Move to next client on each Tab-press
 	 elseif (key == tab or key == "Right") and event == "press" then
 	    altTabIndex = cycle(altTabTable, altTabIndex, 1)
-	    
+
       	    -- Move to previous client on Shift-Tab
 	 elseif (key == shift_tab or key == "Left") and event == "press" then
 	    altTabIndex = cycle(altTabTable, altTabIndex, -1)


### PR DESCRIPTION
When I use some applications such as Xnest, awesome-switcher is not able to show the icon/name in the preview. Here a patch to fix this issue.
Note that I also removed some extra spaces in a separate commit.