### PR TITLE
4 useful patches, plus a new opacity approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Optionally edit any subset of the following settings, the defaults are:
     
     switcher.settings.client_opacity = false,                             -- opacity for unselected clients
     switcher.settings.client_opacity_value = 0.5,                         -- alpha-value
-    switcher.settings.client_opacity_delay = 150,                         -- delay in ms
 ```
 
 Then add key-bindings.  On my particular system, and I guess most,

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Optionally edit any subset of the following settings, the defaults are:
     switcher.settings.preview_box_title_color = {0,0,0,1},                -- the font color
     
     switcher.settings.client_opacity = false,                             -- opacity for unselected clients
-    switcher.settings.client_opacity_value = 0.5,                         -- alpha-value
+    switcher.settings.client_opacity_value = 0.8,                         -- alpha-value
+    switcher.settings.client_opacity_value_in_focus = 0.2,                -- alpha-value for the current in-focus client
 ```
 
 Then add key-bindings.  On my particular system, and I guess most,

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Optionally edit any subset of the following settings, the defaults are:
     switcher.settings.preview_box_title_color = {0,0,0,1},                -- the font color
     
     switcher.settings.client_opacity = false,                             -- opacity for unselected clients
-    switcher.settings.client_opacity_value = 0.8,                         -- alpha-value
-    switcher.settings.client_opacity_value_in_focus = 0.2,                -- alpha-value for the current in-focus client
+    switcher.settings.client_opacity_value = 0.5,                         -- alpha-value for any client
+    switcher.settings.client_opacity_value_in_focus = 0.5,                -- alpha-value for the client currently in focus
+    switcher.settings.client_opacity_value_selected = 1,                  -- alpha-value for the selected client
 ```
 
 Then add key-bindings.  On my particular system, and I guess most,

--- a/init.lua
+++ b/init.lua
@@ -38,7 +38,6 @@ local settings = {
 
    client_opacity = false,
    client_opacity_value = 0.5,
-   client_opacity_delay = 150,
 }
 
 -- Create a wibox to contain all the client-widgets
@@ -436,16 +435,6 @@ local function switch(dir, alt, tab, shift_tab)
    end)
    previewDelayTimer:start()
 
-   -- opacity delay timer
-   local opacityDelay = settings.client_opacity_delay / 1000
-   local opacityDelayTimer = timer({timeout = opacityDelay})
-   opacityDelayTimer:connect_signal("timeout", function()
-				       opacityDelayTimer:stop()
-				       clientOpacity()
-   end)
-   opacityDelayTimer:start()
-
-
    -- Now that we have collected all windows, we should run a keygrabber
    -- as long as the user is alt-tabbing:
    keygrabber.run(
@@ -455,7 +444,6 @@ local function switch(dir, alt, tab, shift_tab)
 	    preview_wbox.visible = false
 	    preview_live_timer:stop()
 	    previewDelayTimer:stop()
-	    opacityDelayTimer:stop()
 
 	    if key == "Escape" then
                for i = 1, #altTabTable do

--- a/init.lua
+++ b/init.lua
@@ -37,8 +37,9 @@ local settings = {
    preview_box_title_color = {0,0,0,1},
 
    client_opacity = false,
-   client_opacity_value = 0.8,
-   client_opacity_value_in_focus = 0.2,
+   client_opacity_value_selected = 1,
+   client_opacity_value_in_focus = 0.5,
+   client_opacity_value = 0.5,
 }
 
 -- Create a wibox to contain all the client-widgets
@@ -370,20 +371,22 @@ end
 local function clientOpacity()
    if not settings.client_opacity then return end
 
+   local opacity = settings.client_opacity_value
+   if opacity > 1 then opacity = 1 end
    for i,data in pairs(altTabTable) do
-      data.client.opacity = 0
+      data.client.opacity = opacity
    end
 
    if client.focus == altTabTable[altTabIndex].client then
       -- Let's normalize the value up to 1.
-      local opacityFocusSelected = settings.client_opacity_value + settings.client_opacity_value_in_focus
+      local opacityFocusSelected = settings.client_opacity_value_selected + settings.client_opacity_value_in_focus
       if opacityFocusSelected > 1 then opacityFocusSelected = 1 end
       client.focus.opacity = opacityFocusSelected
    else
       -- Let's normalize the value up to 1.
       local opacityFocus = settings.client_opacity_value_in_focus
       if opacityFocus > 1 then opacityFocus = 1 end
-      local opacitySelected = settings.client_opacity_value
+      local opacitySelected = settings.client_opacity_value_selected
       if opacitySelected > 1 then opacitySelected = 1 end
 
       client.focus.opacity = opacityFocus

--- a/init.lua
+++ b/init.lua
@@ -52,7 +52,6 @@ local preview_widgets = {}
 
 local altTabTable = {}
 local altTabIndex = 1
-local applyOpacity = false
 
 local source = string.sub(debug.getinfo(1,'S').source, 2)
 local path = string.sub(source, 1, string.find(source, "/[^/]*$"))
@@ -380,13 +379,13 @@ local function showPreview()
 end
 
 
-local function clientOpacity(altTabIndex)
+local function clientOpacity()
    if not settings.client_opacity then return end
 
    for i,data in pairs(altTabTable) do
       if i == altTabIndex then
 	 data.client.opacity = 1
-      elseif applyOpacity then
+      else
 	 data.client.opacity = settings.client_opacity_value
       end
    end
@@ -409,7 +408,7 @@ local function cycle(dir)
    end
 
    if settings.client_opacity then
-      clientOpacity(altTabIndex)
+      clientOpacity()
    end
 end
 
@@ -441,9 +440,8 @@ local function switch(dir, alt, tab, shift_tab)
    local opacityDelay = settings.client_opacity_delay / 1000
    local opacityDelayTimer = timer({timeout = opacityDelay})
    opacityDelayTimer:connect_signal("timeout", function()
-				       applyOpacity = true
 				       opacityDelayTimer:stop()
-				       clientOpacity(altTabIndex)
+				       clientOpacity()
    end)
    opacityDelayTimer:start()
 
@@ -455,7 +453,6 @@ local function switch(dir, alt, tab, shift_tab)
 	 -- Stop alt-tabbing when the alt-key is released
 	 if key == alt or key == "Escape" and event == "release" then
 	    preview_wbox.visible = false
-	    applyOpacity = false
 	    preview_live_timer:stop()
 	    previewDelayTimer:stop()
 	    opacityDelayTimer:stop()

--- a/init.lua
+++ b/init.lua
@@ -471,7 +471,7 @@ local function switch(dir, alt, tab, shift_tab)
                   if i ~= altTabIndex and altTabTable[i].minimized then
                      altTabTable[i].client.minimized = true
                   end
-                  altTabTable[i].client.opacity = altTabtable[i].opacity
+                  altTabTable[i].client.opacity = altTabTable[i].opacity
                end
             end
 

--- a/init.lua
+++ b/init.lua
@@ -37,7 +37,8 @@ local settings = {
    preview_box_title_color = {0,0,0,1},
 
    client_opacity = false,
-   client_opacity_value = 0.5,
+   client_opacity_value = 0.8,
+   client_opacity_value_in_focus = 0.2,
 }
 
 -- Create a wibox to contain all the client-widgets
@@ -366,6 +367,30 @@ local function updatePreview()
    end
 end
 
+local function clientOpacity()
+   if not settings.client_opacity then return end
+
+   for i,data in pairs(altTabTable) do
+      data.client.opacity = 0
+   end
+
+   if client.focus == altTabTable[altTabIndex].client then
+      -- Let's normalize the value up to 1.
+      local opacityFocusSelected = settings.client_opacity_value + settings.client_opacity_value_in_focus
+      if opacityFocusSelected > 1 then opacityFocusSelected = 1 end
+      client.focus.opacity = opacityFocusSelected
+   else
+      -- Let's normalize the value up to 1.
+      local opacityFocus = settings.client_opacity_value_in_focus
+      if opacityFocus > 1 then opacityFocus = 1 end
+      local opacitySelected = settings.client_opacity_value
+      if opacitySelected > 1 then opacitySelected = 1 end
+
+      client.focus.opacity = opacityFocus
+      altTabTable[altTabIndex].client.opacity = opacitySelected
+   end
+end
+
 -- This starts the timer for updating and it shows the preview UI.
 local function showPreview()
    preview_live_timer.timeout = 1 / settings.preview_box_fps
@@ -373,23 +398,10 @@ local function showPreview()
    preview_live_timer:start()
 
    preview()
-
    preview_wbox.visible = true
+
+   clientOpacity()
 end
-
-
-local function clientOpacity()
-   if not settings.client_opacity then return end
-
-   for i,data in pairs(altTabTable) do
-      if i == altTabIndex then
-	 data.client.opacity = 1
-      else
-	 data.client.opacity = settings.client_opacity_value
-      end
-   end
-end
-
 
 local function cycle(dir)
    -- Switch to next client

--- a/init.lua
+++ b/init.lua
@@ -406,7 +406,7 @@ local function cycle(dir)
       client.focus = altTabTable[altTabIndex].client
    end
 
-   if settings.client_opacity then
+   if settings.client_opacity and preview_wbox.visible then
       clientOpacity()
    end
 end


### PR DESCRIPTION
The first 4 patches are needed. The last 3 implement a new algorithm for the opacity. Note that it is back compatible, but it introduces 2 new settings:

switcher.settings.client_opacity_value_in_focus - opacity for the client currently in focus
switcher.settings.client_opacity_value_selected - opacity for the selected client.

personally I use these values:

switcher.settings.client_opacity_value = 0
switcher.settings.client_opacity_in_focus = 0.2
switcher.settings.client_opacity_selected = 0.8

Basically you have a full control of the opacity values for any kind of client: focus, selected, anything else.